### PR TITLE
fix: harden CLI path validation

### DIFF
--- a/.github/workflows/devops.yml
+++ b/.github/workflows/devops.yml
@@ -82,7 +82,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload code coverage report artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: code-coverage-report
           path: coverage/coverage_report/
@@ -107,7 +107,7 @@ jobs:
           pdoc --force --html $(git ls-files "*.py") --output-dir docs/
 
       - name: Upload code documentation artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: code-documentation
           path: docs/

--- a/.github/workflows/devops.yml
+++ b/.github/workflows/devops.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Run unit tests
         shell: bash
         run: |
-          pip install pytest --quiet
+          pip install -r requirements.txt pytest --quiet
           pytest tests/ --quiet
 
   pytest-cov:

--- a/.github/workflows/devops.yml
+++ b/.github/workflows/devops.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Generate code coverage report
         shell: bash
         run: |
-          pip install pytest-cov coveralls --quiet
+          pip install -r requirements.txt pytest-cov coveralls --quiet
           pytest --cov tests/ --cov-report html:coverage/coverage_report/ --cov-config coverage/.coveragerc
 
       - name: Upload code coverage report to Coveralls

--- a/tests/test_umlement_cli.py
+++ b/tests/test_umlement_cli.py
@@ -1,4 +1,7 @@
 from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from umlement import UMLement
 

--- a/tests/test_umlement_cli.py
+++ b/tests/test_umlement_cli.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+
+from umlement import UMLement
+
+
+class TestValidateArgvsProvided:
+    def test_accepts_python_file(self, tmp_path: Path) -> None:
+        script_file = tmp_path / "demo.py"
+        script_file.write_text("class Demo:\n    pass\n", encoding="utf-8")
+
+        app = UMLement()
+
+        assert app.validate_argvs_provided([str(script_file)]) is True
+        assert app.generator.py_files == [str(script_file)]
+
+    def test_rejects_missing_paths(self, tmp_path: Path) -> None:
+        missing_file = tmp_path / "missing.py"
+
+        app = UMLement()
+
+        assert app.validate_argvs_provided([str(missing_file)]) is False
+        assert app.generator.py_files == []
+
+    def test_collects_only_python_files_from_folder(self, tmp_path: Path) -> None:
+        python_file = tmp_path / "alpha.py"
+        text_file = tmp_path / "notes.txt"
+        nested_dir = tmp_path / "nested"
+        python_file.write_text("class Alpha:\n    pass\n", encoding="utf-8")
+        text_file.write_text("ignore me", encoding="utf-8")
+        nested_dir.mkdir()
+
+        app = UMLement()
+
+        assert app.validate_argvs_provided([str(tmp_path)]) is True
+        assert app.generator.py_files == [str(python_file)]
+
+    def test_resets_previous_python_files_between_runs(self, tmp_path: Path) -> None:
+        first_file = tmp_path / "first.py"
+        second_file = tmp_path / "second.py"
+        first_file.write_text("class First:\n    pass\n", encoding="utf-8")
+        second_file.write_text("class Second:\n    pass\n", encoding="utf-8")
+
+        app = UMLement()
+
+        assert app.validate_argvs_provided([str(first_file)]) is True
+        assert app.generator.py_files == [str(first_file)]
+
+        assert app.validate_argvs_provided([str(second_file)]) is True
+        assert app.generator.py_files == [str(second_file)]

--- a/umlement.py
+++ b/umlement.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-import os
+from pathlib import Path
 import shutil
 import sys
 from colorama import (init, deinit, Fore, Style)
@@ -20,6 +20,13 @@ class UMLement():
     def generate_class_inheritance_diagram(self):
         self.generator.generate_class_inheritance_diagram()
 
+    def _append_python_path(self, path: Path) -> None:
+        if path.is_file() and path.suffix.lower() == ".py":
+            self.generator.py_files.append(str(path))
+            return
+
+        print(rf"{Fore.LIGHTBLACK_EX}{path} ignored, non-python files are unsupported{Style.RESET_ALL}")
+
     def validate_argvs_provided(self, argvs_provided: list[str]) -> bool:
         min_argvs_required: int = 1
 
@@ -28,24 +35,21 @@ class UMLement():
             print(f"{Fore.RED}an insufficient # of script arguments were provided (provided: {len(argvs_provided)}, expected: {min_argvs_required}){Style.RESET_ALL}")
             return False
 
-        # nested function to append `.py` files to the `UMLGenerator.py_files` list
-        def append_py_file(file_path: str) -> None:
-            self.generator.py_files.append(file_path) if bool(file_path.lower().endswith(".py")) else print(rf"{Fore.LIGHTBLACK_EX}{file_path} ignored, non-python files are unsupported{Style.RESET_ALL}")
+        self.generator.py_files = []
 
         for argv in argvs_provided:
-            # check if the script argv provided is a file or folder path
-            is_folder_path: bool = True if '.' not in argv else False
+            path = Path(argv)
 
-            if is_folder_path:
-                folder_path: str = argv
+            if not path.exists():
+                print(f"{Fore.RED}{path} not found{Style.RESET_ALL}")
+                continue
 
-                for file in os.listdir(folder_path):
-                    path: str = f"{folder_path}/{file}"
-                    append_py_file(path)
+            if path.is_dir():
+                for file_path in sorted(path.iterdir()):
+                    self._append_python_path(file_path)
+                continue
 
-            else:
-                file_path: str = argv
-                append_py_file(file_path)
+            self._append_python_path(path)
 
         # check if atleast 1 index in the self.generator.py_files list contains a `.py` file
         if len(self.generator.py_files) < 1:
@@ -85,5 +89,5 @@ if __name__ == "__main__":
         print(f"{Fore.RED}class inheritance model & diagram creation failed: {e}{Style.RESET_ALL}")
 
         # remove the directory containing any partically created `.puml` model and/or `.png` diagram files
-        if os.path.exists(PLANTUML_MODEL_DIR):
+        if Path(PLANTUML_MODEL_DIR).exists():
             shutil.rmtree(f"{PLANTUML_MODEL_DIR}")


### PR DESCRIPTION
## Summary
- replace the fragile argv path heuristic with real filesystem checks
- ignore missing and non-Python paths cleanly
- reset collected Python files between validation runs
- add CLI regression tests for file, folder, and missing-path behavior

## Testing
- .venv/bin/python -m pytest tests/